### PR TITLE
Make it easier to change package name by updating configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,4 +15,5 @@ PKG_CHECK_MODULES(LIBTORRENT, libtorrent-rasterbar >= 1.0.0)
 # Check libtool
 LT_INIT
 
+AC_CONFIG_HEADERS(src/config.h)
 AC_OUTPUT(Makefile src/Makefile)

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with vlc-bittorrent.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
+
 #include <string>
 #include <algorithm>
 
@@ -100,7 +102,7 @@ DataOpen(vlc_object_t *p_this)
 
 	save_path += vlc_download_dir;
 	save_path += DIR_SEP;
-	save_path += "vlc-bittorrent";
+	save_path += PACKAGE;
 
 	vlc_mkdir(vlc_download_dir, 0777);
 	vlc_mkdir(save_path.c_str(), 0777);

--- a/src/magnetmetadata.cpp
+++ b/src/magnetmetadata.cpp
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with vlc-bittorrent.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "config.h"
 #include "libtorrent.h"
 #include "vlc.h"
 
@@ -83,7 +84,7 @@ MagnetMetadataOpen(vlc_object_t *p_this)
 
 	save_path += vlc_download_dir;
 	save_path += DIR_SEP;
-	save_path += "vlc-bittorrent";
+	save_path += PACKAGE;
 
 	vlc_mkdir(vlc_download_dir, 0777);
 	vlc_mkdir(save_path.c_str(), 0777);


### PR DESCRIPTION
Make sure all directories created using the package name fetches
the name from configure.ac instead of hardcoding the string.