### PR TITLE
Change name in configure.ac from vlc-bittorrent to vlc-plugin-bittorrent.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT(vlc-bittorrent, 2.0, johan.gunnarsson@gmail.com, vlc-bittorrent, https://github.com/johang/vlc-bittorrent)
+AC_INIT(vlc-plugin-bittorrent, 2.0, johan.gunnarsson@gmail.com, vlc-bittorrent, https://github.com/johang/vlc-bittorrent)
 AC_CONFIG_SRCDIR([src/module.cpp])
 
 # Check programs


### PR DESCRIPTION
This bring the package name more in line with other VLC plugin packages in Debian.