### PR TITLE
macOS fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AC_REQUIRE_AUX_FILE([tap-driver.sh])
 
+CXXFLAGS="$CXXFLAGS -std=c++11"
+
 # Check programs
 AC_PROG_CXX
 AC_PROG_AWK

--- a/src/vlc.cpp
+++ b/src/vlc.cpp
@@ -21,6 +21,7 @@ along with vlc-bittorrent.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <string>
 #include <stdexcept>
+#include <errno.h>
 
 #include "vlc.h"
 


### PR DESCRIPTION
These were required to build without errors on macOS Mojave.