### PR TITLE
Avoid implicit conversion from int to unsigned char for download_priority value

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AM_INIT_AUTOMAKE
 
 # Check libraries
 PKG_CHECK_MODULES(VLC_PLUGIN, vlc-plugin >= 3.0.0)
-PKG_CHECK_MODULES(LIBTORRENT, libtorrent-rasterbar >= 1.0.0)
+PKG_CHECK_MODULES(LIBTORRENT, libtorrent-rasterbar >= 1.2.0)
 
 # Check libvlc library only if --with-tests
 AC_ARG_WITH(

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -320,7 +320,7 @@ Download::read(int file, int64_t fileoff, char* buf, size_t buflen,
 }
 
 void
-Download::set_piece_priority(int file, int64_t off, int size, int prio)
+Download::set_piece_priority(int file, int64_t off, int size, libtorrent::download_priority_t prio)
 {
     D(printf("%s:%d: %s()\n", __FILE__, __LINE__, __func__));
 

--- a/src/download.h
+++ b/src/download.h
@@ -130,7 +130,7 @@ private:
     read(lt::peer_request part, char* buf, size_t buflen);
 
     void
-    set_piece_priority(int file, int64_t off, int size, int prio);
+    set_piece_priority(int file, int64_t off, int size, libtorrent::download_priority_t prio);
 
     // Locks mutex passed to constructor
     std::unique_lock<std::mutex> m_lock;


### PR DESCRIPTION
Get rid of this warning from GCC 14, while ensuring the same type is used from the value is provided until is is passed into libtorrent:

download.cpp: In member function 'void Download::set_piece_priority(int, int64_t, int, int)': download.cpp:343:45: warning: conversion from 'int' to 'unsigned char' may change value [-Wconversion]
  343 |             m_th.piece_priority(part.piece, prio);
      |                                             ^~~~