### PR TITLE
Fix Windows VLC/libtorrent header conflicts

### DIFF
--- a/src/download.cpp
+++ b/src/download.cpp
@@ -35,8 +35,6 @@ XXX: This file is basically just glue code so vlc can make interruptible
 #include <stdexcept>
 
 #include "download.h"
-#include "session.h"
-#include "vlc.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
@@ -53,6 +51,8 @@ XXX: This file is basically just glue code so vlc can make interruptible
 #include <libtorrent/torrent_info.hpp>
 #include <libtorrent/version.hpp>
 #pragma GCC diagnostic pop
+
+#include "vlc.h"
 
 #define D(x)
 #define DD(x)

--- a/src/vlc.h
+++ b/src/vlc.h
@@ -24,6 +24,14 @@ along with vlc-bittorrent.  If not, see <http://www.gnu.org/licenses/>.
 #include "config.h"
 #endif
 
+#ifdef _WIN32
+#include <winsock2.h>
+// VLC's Windows thread helpers expect poll() to exist.
+#ifndef poll
+#define poll WSAPoll
+#endif
+#endif
+
 #include <string>
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
This fixes the Windows-specific header collisions that prevented `vlc-bittorrent` from building against VLC/libtorrent on a MinGW/MSYS2 toolchain.

Changes:
- include `winsock2.h` so VLC's Windows thread helpers can resolve `poll()` via `WSAPoll`
- temporarily hide VLC's `poll` and `snprintf` macros while including libtorrent/Boost headers
- provide fallback definitions for `MODULE_STRING` and `PACKAGE` when they are not injected by the build

Validation:
- built a working plugin DLL on Windows with MSYS2/mingw64
- verified VLC loads the `bittorrent` stream_directory module when opening a `.torrent`